### PR TITLE
Add lexicon tests

### DIFF
--- a/src/main/resources/Lexicon_v2.xml
+++ b/src/main/resources/Lexicon_v2.xml
@@ -2051,7 +2051,7 @@
 			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Vienskaitlis" Izteiksme="Pavēles" Persona="2" Laiks="Nepiemīt" Kārta="Darāmā"/>
 		</Ending>
 		<Ending ID="251" StemChange="0" Ending="jiet" StemID="1" LemmaEnding="225">
-			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Daudzskaitlis" Izteiksme="Pavēles" Persona="2" Laiks="Nepiemīt"/>
+			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Daudzskaitlis" Izteiksme="Pavēles" Persona="2" Laiks="Nepiemīt" Kārta="Darāmā"/>
 		</Ending>
 		<Ending ID="252" StemChange="0" Ending="jošs" StemID="1" LemmaEnding="225">
 			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Vienskaitlis" Noteiktība="Nenoteiktā" Izteiksme="Divdabis" Dzimte="Vīriešu" Locījums="Nominatīvs" Lokāmība="Lokāms" Pakāpe="Pamata" Laiks="Tagadne" Kārta="Darāmā"/>
@@ -3194,7 +3194,7 @@
 			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Daudzskaitlis" Izteiksme="Īstenības" Persona="2" Laiks="Nākotne" Kārta="Darāmā" Ģenerēt="Nē"/>
 		</Ending>
 		<Ending ID="1203" StemChange="4" Ending="jot" StemID="1" LemmaEnding="225">
-			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Nepiemīt" Izteiksme="Vajadzības, atstāstījuma paveids" Persona="Nepiemīt" Laiks="Tagadne" Kārta="Darāmā"/>
+			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Nepiemīt" Izteiksme="Vajadzības, atstāstījuma paveids" Persona="Nepiemīt" Laiks="Nepiemīt" Kārta="Darāmā"/>
 		</Ending>
 	</Paradigm>
 	<Paradigm Stems="1" ID="17" Name="verb-3a" LemmaEnding="468" Description="Darbības vārdi, 3. konjugācija, tiešie, bez tagadnes mijas (lasīt)" AllowedGuessEndings="āēī">
@@ -4739,7 +4739,7 @@
 			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Nepiemīt" Izteiksme="Atstāstījuma" Persona="Nepiemīt" Laiks="Tagadne" Kārta="Darāmā"/>
 		</Ending>
 		<Ending ID="1032" StemChange="0" Ending="šoties" StemID="1" LemmaEnding="1008">
-			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Nepiemīt" Izteiksme="Atstāstījuma" Persona="Nepiemīt" Laiks="Nākotne"/>
+			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Nepiemīt" Izteiksme="Atstāstījuma" Persona="Nepiemīt" Laiks="Nākotne" Kārta="Darāmā"/>
 		</Ending>
 		<Ending ID="1033" StemChange="2" Ending="ies" StemID="1" LemmaEnding="1008">
 			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Vienskaitlis" Izteiksme="Pavēles" Persona="2" Laiks="Nepiemīt" Kārta="Darāmā"/>
@@ -6819,7 +6819,7 @@
 			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Nepiemīt" Izteiksme="Atstāstījuma" Persona="Nepiemīt" Laiks="Tagadne" Kārta="Darāmā"/>
 		</Ending>
 		<Ending ID="2354" StemChange="0" Ending="šoties" StemID="1" LemmaEnding="2336">
-			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Nepiemīt" Izteiksme="Atstāstījuma" Persona="Nepiemīt" Laiks="Nākotne"/>
+			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Nepiemīt" Izteiksme="Atstāstījuma" Persona="Nepiemīt" Laiks="Nākotne" Kārta="Darāmā"/>
 		</Ending>
 		<Ending ID="2355" StemChange="26" Ending="ies" StemID="1" LemmaEnding="2336">
 			<Attributes Vārdšķira="Darbības vārds" Skaitlis="Vienskaitlis" Izteiksme="Pavēles" Persona="2" Laiks="Nepiemīt" Kārta="Darāmā"/>

--- a/src/test/java/lv/semti/morphology/Testi/JSONLexiconTest.java
+++ b/src/test/java/lv/semti/morphology/Testi/JSONLexiconTest.java
@@ -10,9 +10,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class JSONLexiconTest {
     @Test
@@ -48,6 +46,28 @@ public class JSONLexiconTest {
             compare_lexicons(analyzer_json, "tēzaurs", analyzer_xml, "lexicon");
 
 
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    /**
+     * For some reason some lexemes have all obligatory attributes (e.g. absolvents) and some do not (e.g. lietotājs).
+     * We should guarantee uniform lexicon.
+     */
+    public void guaranteeObligatoryLexemeAttributes() {
+        try {
+            Analyzer analyzer_json = new Analyzer("Lexicon_v2.xml");
+            for (Paradigm paradigm : analyzer_json.paradigms) {
+                for (Lexeme lexeme : paradigm.lexemes) {
+                    assertNotNull("Word with lexeme ID " + lexeme.getID() + " must have lemma", lexeme.getValue(AttributeNames.i_Lemma));
+                    assertNotNull("Word `" + lexeme.getValue(AttributeNames.i_Lemma) + "` must have attribute: `" + AttributeNames.i_ParadigmID + "`", lexeme.getValue(AttributeNames.i_ParadigmID));
+                    assertNotNull("Word `" + lexeme.getValue(AttributeNames.i_Lemma) + "` must have attribute: `" + AttributeNames.i_LexemeID + "`", lexeme.getValue(AttributeNames.i_LexemeID));
+                    assertNotNull("Word `" + lexeme.getValue(AttributeNames.i_Lemma) + "` must have attribute: `" + AttributeNames.i_EntryID + "`", lexeme.getValue(AttributeNames.i_EntryID));
+                    assertEquals(Integer.valueOf(lexeme.getValue(AttributeNames.i_ParadigmID)), new Integer(paradigm.getID()));
+                }
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
For some reason some lexemes have all obligatory attributes (e.g. absolvents) and some do not (e.g. lietotājs).
We should guarantee uniform lexicon.